### PR TITLE
Fix PDF downloading when matrix server is different from server name

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -10,7 +10,7 @@ function getRoomWithState(roomId) {
 }
 
 function getHttpUriForMxcFromHS(...theArgs) {
-  return Matrix.getHttpUriForMxc(`https://${this.getDomain()}`, ...theArgs)
+  return Matrix.getHttpUriForMxc(this.getHomeserverUrl(), ...theArgs)
 }
 
 export default class Client {


### PR DESCRIPTION
When the matrix server public url is different then the server name, the code tries to download the PDF from the wrong server.  Fix to use the homeserver url.